### PR TITLE
Add pytest mock to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ py==1.4.34
 pytest==3.2.3
 pytest-django==3.1.2
 python-decouple==3.1
-pytest-mock-1.6.3
+pytest-mock==1.6.3
 pytz==2017.2
 six==1.11.0
 whitenoise==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ py==1.4.34
 pytest==3.2.3
 pytest-django==3.1.2
 python-decouple==3.1
+pytest-mock-1.6.3
 pytz==2017.2
 six==1.11.0
 whitenoise==3.2


### PR DESCRIPTION
Tests were failing because the pytest-mock library was not installed. Including it on requirements.txt